### PR TITLE
Capitalize method argument when merging

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -61,6 +61,8 @@ module.exports = function (base, vargs, ua) {
                 merged.method = name.toUpperCase()
             } else if (name == 'body') {
                 merged.payload = varg.body
+            } else if (name == 'method') {
+                merged.method = varg.method.toUpperCase()
             } else {
                 merged[name] = varg[name]
             }

--- a/t/merge.t.js
+++ b/t/merge.t.js
@@ -1,4 +1,4 @@
-require('proof')(10, prove)
+require('proof')(11, prove)
 
 function prove (okay) {
     var merge = require('../merge')
@@ -18,5 +18,6 @@ function prove (okay) {
         okay(true, 'cc depricated')
     }
     okay(merge({ put: {} }, []), { method: 'PUT', payload: {} }, 'put')
+    okay(merge({ method: 'post', body: {} }, []), { method: 'POST', payload: {} }, 'post')
     okay(merge({ body: {} }, []), { payload: {} }, 'body')
 }


### PR DESCRIPTION
Since method is capitalized when passing a `put` or `post` argument, it seems like it should also be capitalized when passing method directly.

Let me know if the test should be put elsewhere.